### PR TITLE
Update Formik example to include imports

### DIFF
--- a/content/docs/components/form-control/usage.mdx
+++ b/content/docs/components/form-control/usage.mdx
@@ -138,6 +138,8 @@ Form Libraries like [Formik](https://jaredpalmer.com/formik/) make it soooo easy
 to manage form state and validation. I 💖 Formik
 
 ```jsx
+import { Field, Form, Formik } from '@formik';
+
 function FormikExample() {
   function validateName(value) {
     let error


### PR DESCRIPTION
Closes https://github.com/chakra-ui/chakra-ui/issues/3866 (technically stale, but still relevant issue) 

## 📝 Description

I was just working through this example and it wasn't initially clear that in addition to `Formik` `Field` and `Form` were from formik rather than chakra-ui.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

While absolutely optional, I find this personally helpful when being new to both Chakra and Formik to understand where each of the imports in the example is coming from. Since the initial docs start with the required imports from Chakra I felt that just including the Formik imports might be enough information to help folks understand. 
